### PR TITLE
Bump required python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = []
 packages = [{ include = "keyring_pass" }]
 
 [tool.poetry.dependencies]
-python = ">=3.7" # requined by `jaraco.classes`
+python = ">=3.9" # required by `functools.cache`
 keyring = "^23.9.3"
 jaraco-classes = "^3.2.3"
 


### PR DESCRIPTION
`functools.cache` (used [here](https://github.com/nazarewk/keyring_pass/blob/c8f5c9f7b3f47c9538628f3b4057f54db166b756/keyring_pass/__init__.py#L28))  was added in Python 3.9 (see [official docs](https://docs.python.org/3/library/functools.html#functools.cache)).